### PR TITLE
feat(api): simplify library with single analyze() function

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -12,7 +12,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 from datetime import datetime
-from pyspark_analyzer import DataFrameProfiler
+from pyspark_analyzer import analyze
 
 
 def create_sample_data():
@@ -58,10 +58,11 @@ def main():
     print("PROFILING ENTIRE DATAFRAME")
     print("=" * 60)
 
-    # Create profiler and generate profile
-    profiler = DataFrameProfiler(df)
-    profile = profiler.profile(
-        output_format="dict"
+    # Generate profile using the analyze function
+    profile = analyze(
+        df,
+        output_format="dict",
+        sampling=False,  # Disable sampling for this small dataset
     )  # Get as dictionary for easier access
 
     # Display overview
@@ -111,7 +112,9 @@ def main():
     print("=" * 60)
 
     # Profile only specific columns
-    numeric_profile = profiler.profile(columns=["age", "salary"], output_format="dict")
+    numeric_profile = analyze(
+        df, columns=["age", "salary"], output_format="dict", sampling=False
+    )
     print("\nNumeric columns only:")
     for col_name, stats in numeric_profile["columns"].items():
         print(

--- a/examples/installation_verification.py
+++ b/examples/installation_verification.py
@@ -17,7 +17,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 from datetime import datetime
-from pyspark_analyzer import DataFrameProfiler
+from pyspark_analyzer import analyze
 
 
 def verify_installation():
@@ -63,9 +63,8 @@ def verify_installation():
 
         # Test basic profiling
         print("\n🔍 Running basic profiling...")
-        profiler = DataFrameProfiler(df)
         # Get profile as dictionary for easier access
-        profile = profiler.profile(output_format="dict")
+        profile = analyze(df, output_format="dict", sampling=False)
 
         # Display results
         overview = profile["overview"]
@@ -75,8 +74,8 @@ def verify_installation():
 
         # Test specific column profiling
         print("\n🎯 Testing specific column profiling...")
-        numeric_profile = profiler.profile(
-            columns=["age", "salary"], output_format="dict"
+        numeric_profile = analyze(
+            df, columns=["age", "salary"], output_format="dict", sampling=False
         )
 
         for col_name, stats in numeric_profile["columns"].items():
@@ -86,8 +85,9 @@ def verify_installation():
 
         # Test performance optimization
         print("\n⚡ Testing performance optimization...")
-        optimized_profiler = DataFrameProfiler(df, optimize_for_large_datasets=True)
-        optimized_profile = optimized_profiler.profile(output_format="dict")
+        optimized_profile = analyze(
+            df, optimize_for_large_datasets=True, output_format="dict", sampling=False
+        )
 
         print(
             f"✅ Optimized profiling completed for {len(optimized_profile['columns'])} columns"
@@ -95,7 +95,7 @@ def verify_installation():
 
         # Test pandas output (new default)
         print("\n🐼 Testing pandas output format...")
-        pandas_profile = profiler.profile()  # Default is pandas
+        pandas_profile = analyze(df, sampling=False)  # Default is pandas
         print(f"✅ Pandas DataFrame shape: {pandas_profile.shape}")
         print(f"✅ Columns in pandas output: {list(pandas_profile.columns)[:5]}...")
 

--- a/examples/pandas_output_example.py
+++ b/examples/pandas_output_example.py
@@ -21,7 +21,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
-from pyspark_analyzer import DataFrameProfiler
+from pyspark_analyzer import analyze
 
 
 def create_sample_data(spark, num_rows=10000):
@@ -83,8 +83,7 @@ def main():
 
     # Example 1: Basic pandas output
     print("\n=== Example 1: Basic Pandas Output ===")
-    profiler = DataFrameProfiler(df)
-    profile_df = profiler.profile()  # Returns pandas DataFrame by default
+    profile_df = analyze(df, sampling=False)  # Returns pandas DataFrame by default
 
     print(f"Profile shape: {profile_df.shape}")
     print("\nFirst few rows:")
@@ -98,11 +97,11 @@ def main():
     print("\n=== Example 2: Saving to Different Formats ===")
 
     # Save to CSV
-    profiler.to_csv("profile_results.csv", index=False)
+    profile_df.to_csv("profile_results.csv", index=False)
     print("✓ Saved to profile_results.csv")
 
     # Save to Parquet (more efficient for larger profiles)
-    profiler.to_parquet("profile_results.parquet")
+    profile_df.to_parquet("profile_results.parquet")
     print("✓ Saved to profile_results.parquet")
 
     # Example 3: Data quality monitoring
@@ -149,8 +148,7 @@ def main():
 
     # Create a filtered dataset (simulate different time period)
     df_filtered = df.filter(df.price > 100)
-    profiler_filtered = DataFrameProfiler(df_filtered)
-    profile_filtered_df = profiler_filtered.profile()
+    profile_filtered_df = analyze(df_filtered, sampling=False)
 
     # Compare the two profiles
     comparison = profile_df.merge(

--- a/examples/simple_api_example.py
+++ b/examples/simple_api_example.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the simplified analyze() API.
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    IntegerType,
+    DoubleType,
+)
+from pyspark_analyzer import analyze
+
+
+def create_sample_data():
+    """Create a sample DataFrame for demonstration."""
+    spark = (
+        SparkSession.builder.appName("SimpleAPIExample")
+        .master("local[*]")
+        .getOrCreate()
+    )
+
+    schema = StructType(
+        [
+            StructField("id", IntegerType(), True),
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("salary", DoubleType(), True),
+            StructField("department", StringType(), True),
+        ]
+    )
+
+    data = [
+        (1, "John Doe", 28, 65000.0, "Engineering"),
+        (2, "Jane Smith", 32, 78000.0, "Marketing"),
+        (3, "Bob Johnson", 45, 92000.0, "Sales"),
+        (4, "Alice Brown", 26, 58000.0, "HR"),
+        (5, "Charlie Wilson", 35, 71000.0, "Engineering"),
+        (6, None, 29, 62000.0, "Marketing"),
+        (7, "Diana Davis", None, 69000.0, "Sales"),
+        (8, "Eve Martinez", 31, None, "HR"),
+        (9, "Frank Miller", 38, 81000.0, None),
+        (10, "Grace Lee", 27, 64000.0, "Engineering"),
+    ]
+
+    return spark.createDataFrame(data, schema)
+
+
+def main():
+    """Main example function demonstrating the simple API."""
+    print("🚀 Creating sample DataFrame...")
+    df = create_sample_data()
+
+    print("\n" + "=" * 70)
+    print("1. BASIC USAGE - Just call analyze()")
+    print("=" * 70)
+
+    # Simplest usage - just pass the DataFrame
+    profile = analyze(df)
+    print(profile)
+
+    print("\n" + "=" * 70)
+    print("2. DISABLE SAMPLING")
+    print("=" * 70)
+
+    # Disable sampling for small datasets
+    profile = analyze(df, sampling=False, output_format="dict")
+    print(f"Total rows processed: {profile['overview']['total_rows']}")
+    print(f"Sampling applied: {profile['sampling']['is_sampled']}")
+
+    print("\n" + "=" * 70)
+    print("3. PROFILE SPECIFIC COLUMNS")
+    print("=" * 70)
+
+    # Analyze only specific columns
+    profile = analyze(df, columns=["age", "salary"], output_format="pandas")
+    print(profile)
+
+    print("\n" + "=" * 70)
+    print("4. GET RESULTS AS DICTIONARY")
+    print("=" * 70)
+
+    # Get results as a dictionary for programmatic access
+    profile = analyze(df, output_format="dict")
+
+    # Access specific statistics
+    age_stats = profile["columns"]["age"]
+    print("Age statistics:")
+    print(f"  Mean: {age_stats['mean']:.1f}")
+    print(f"  Min: {age_stats['min']}")
+    print(f"  Max: {age_stats['max']}")
+    print(f"  Null count: {age_stats['null_count']}")
+
+    print("\n" + "=" * 70)
+    print("5. GET HUMAN-READABLE SUMMARY")
+    print("=" * 70)
+
+    # Get a text summary
+    summary = analyze(df, output_format="summary", include_advanced=False)
+    print(summary)
+
+    print("\n" + "=" * 70)
+    print("6. SAMPLING EXAMPLES (for larger datasets)")
+    print("=" * 70)
+
+    # Create a larger dataset for sampling demo
+    large_data = []
+    for i in range(10000):
+        large_data.append(
+            (
+                i,
+                f"Person {i}",
+                25 + (i % 40),
+                50000.0 + (i % 50000),
+                ["Engineering", "Marketing", "Sales", "HR"][i % 4],
+            )
+        )
+
+    schema = StructType(
+        [
+            StructField("id", IntegerType(), True),
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("salary", DoubleType(), True),
+            StructField("department", StringType(), True),
+        ]
+    )
+
+    large_df = df.sparkSession.createDataFrame(large_data, schema)
+
+    # Sample to 1000 rows
+    print("\nSampling to 1000 rows:")
+    profile = analyze(large_df, target_rows=1000, output_format="dict")
+    print(f"  Original size: {profile['sampling']['original_size']:,} rows")
+    print(f"  Sample size: {profile['sampling']['sample_size']:,} rows")
+
+    # Sample 10% of data
+    print("\nSampling 10% of data:")
+    profile = analyze(large_df, fraction=0.1, output_format="dict")
+    print(f"  Sample size: {profile['sampling']['sample_size']:,} rows")
+    print(f"  Sampling fraction: {profile['sampling']['sampling_fraction']:.2f}")
+
+    print("\n✅ Simple API demonstration completed!")
+
+    # Clean up
+    df.sparkSession.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyspark_analyzer/__init__.py
+++ b/pyspark_analyzer/__init__.py
@@ -5,13 +5,9 @@ A library for generating comprehensive profiles of PySpark DataFrames with stati
 for all columns including null counts, data type specific metrics, and performance optimizations.
 """
 
-from .profiler import DataFrameProfiler
-from .sampling import SamplingConfig
-from .statistics import LazyRowCount
+from .api import analyze
 
 __version__ = "1.0.0"
 __all__ = [
-    "DataFrameProfiler",
-    "SamplingConfig",
-    "LazyRowCount",
+    "analyze",
 ]

--- a/pyspark_analyzer/api.py
+++ b/pyspark_analyzer/api.py
@@ -1,0 +1,141 @@
+from typing import Optional, List, Union, Any
+import pandas as pd
+from pyspark.sql import DataFrame
+
+from .profiler import DataFrameProfiler
+from .sampling import SamplingConfig
+
+
+def analyze(
+    df: DataFrame,
+    *,
+    sampling: Optional[bool] = None,
+    target_rows: Optional[int] = None,
+    fraction: Optional[float] = None,
+    columns: Optional[List[str]] = None,
+    output_format: str = "pandas",
+    include_advanced: bool = True,
+    include_quality: bool = True,
+    optimize_for_large_datasets: bool = False,
+    auto_threshold: Optional[int] = None,
+    seed: Optional[int] = None,
+) -> Union[pd.DataFrame, dict, str]:
+    """
+    Analyze a PySpark DataFrame and generate comprehensive statistics.
+
+    This is the simplified entry point for profiling DataFrames. It automatically
+    handles sampling configuration based on the provided parameters.
+
+    Args:
+        df: PySpark DataFrame to analyze
+        sampling: Whether to enable sampling. If None, auto-sampling is enabled for large datasets.
+                 If False, no sampling. If True, uses default sampling.
+        target_rows: Sample to approximately this many rows. Mutually exclusive with fraction.
+        fraction: Sample this fraction of the data (0.0-1.0). Mutually exclusive with target_rows.
+        columns: List of specific columns to profile. If None, profiles all columns.
+        output_format: Output format ("pandas", "dict", "json", "summary"). Default is "pandas".
+        include_advanced: Include advanced statistics (skewness, kurtosis, outliers, etc.)
+        include_quality: Include data quality metrics
+        optimize_for_large_datasets: Use optimized batch processing for better performance
+        auto_threshold: Custom threshold for auto-sampling (default: 10,000,000 rows)
+        seed: Random seed for reproducible sampling
+
+    Returns:
+        Profile results in the requested format:
+        - "pandas": pandas DataFrame with statistics
+        - "dict": Python dictionary
+        - "json": JSON string
+        - "summary": Human-readable summary string
+
+    Examples:
+        >>> # Basic usage with auto-sampling
+        >>> profile = analyze(df)
+
+        >>> # Disable sampling
+        >>> profile = analyze(df, sampling=False)
+
+        >>> # Sample to 100,000 rows
+        >>> profile = analyze(df, target_rows=100_000)
+
+        >>> # Sample 10% of data
+        >>> profile = analyze(df, fraction=0.1)
+
+        >>> # Profile specific columns only
+        >>> profile = analyze(df, columns=["age", "salary"])
+
+        >>> # Get results as dictionary
+        >>> profile = analyze(df, output_format="dict")
+    """
+    # Build sampling configuration based on parameters
+    sampling_config = _build_sampling_config(
+        sampling=sampling,
+        target_rows=target_rows,
+        fraction=fraction,
+        auto_threshold=auto_threshold,
+        seed=seed,
+    )
+
+    # Create profiler and generate profile
+    profiler = DataFrameProfiler(
+        df,
+        optimize_for_large_datasets=optimize_for_large_datasets,
+        sampling_config=sampling_config,
+    )
+
+    return profiler.profile(
+        columns=columns,
+        output_format=output_format,
+        include_advanced=include_advanced,
+        include_quality=include_quality,
+    )
+
+
+def _build_sampling_config(
+    sampling: Optional[bool],
+    target_rows: Optional[int],
+    fraction: Optional[float],
+    auto_threshold: Optional[int],
+    seed: Optional[int],
+) -> SamplingConfig:
+    """
+    Build SamplingConfig from simplified parameters.
+
+    Args:
+        sampling: Whether to enable sampling
+        target_rows: Target number of rows to sample
+        fraction: Fraction of data to sample
+        auto_threshold: Custom auto-sampling threshold
+        seed: Random seed
+
+    Returns:
+        SamplingConfig instance
+
+    Raises:
+        ValueError: If both target_rows and fraction are specified
+    """
+    if target_rows is not None and fraction is not None:
+        raise ValueError("Cannot specify both target_rows and fraction")
+
+    # If sampling is explicitly disabled
+    if sampling is False:
+        return SamplingConfig(enabled=False)
+
+    # Build config with specified parameters
+    config_params: dict[str, Any] = {}
+
+    if sampling is not None:
+        config_params["enabled"] = sampling
+
+    if target_rows is not None:
+        config_params["target_rows"] = target_rows
+
+    if fraction is not None:
+        config_params["fraction"] = fraction
+
+    if auto_threshold is not None:
+        config_params["auto_threshold"] = auto_threshold
+
+    if seed is not None:
+        config_params["seed"] = seed
+
+    return SamplingConfig(**config_params)

--- a/pyspark_analyzer/profiler.py
+++ b/pyspark_analyzer/profiler.py
@@ -1,5 +1,7 @@
 """
-Main DataFrame profiler class for PySpark DataFrames.
+Internal DataFrame profiler implementation for PySpark DataFrames.
+
+This module is for internal use only. Use the `analyze()` function from the main package instead.
 """
 
 import pandas as pd
@@ -263,109 +265,3 @@ class DataFrameProfiler:
             "sampling_time": self.sampling_metadata.sampling_time,
             "estimated_speedup": self.sampling_metadata.speedup_estimate,
         }
-
-    def to_csv(self, path: str, **kwargs: Any) -> None:
-        """
-        Save profile results to CSV file.
-
-        Args:
-            path: Path to save the CSV file
-            **kwargs: Additional arguments passed to pandas.DataFrame.to_csv()
-        """
-        df = self.profile(output_format="pandas")
-        if hasattr(df, "to_csv"):
-            df.to_csv(path, **kwargs)
-
-    def to_parquet(self, path: str, **kwargs: Any) -> None:
-        """
-        Save profile results to Parquet file.
-
-        Args:
-            path: Path to save the Parquet file
-            **kwargs: Additional arguments passed to pandas.DataFrame.to_parquet()
-        """
-        df = self.profile(output_format="pandas")
-        if hasattr(df, "to_parquet"):
-            df.to_parquet(path, **kwargs)
-
-    def to_sql(self, name: str, con: Any, **kwargs: Any) -> None:
-        """
-        Save profile results to SQL database table.
-
-        Args:
-            name: Name of the SQL table
-            con: SQLAlchemy engine or DBAPI2 connection
-            **kwargs: Additional arguments passed to pandas.DataFrame.to_sql()
-        """
-        df = self.profile(output_format="pandas")
-        if hasattr(df, "to_sql"):
-            df.to_sql(name, con, **kwargs)
-
-    def format_output(
-        self, format_type: str = "pandas"
-    ) -> Union[pd.DataFrame, Dict[str, Any], str]:
-        """
-        Get profile output in specified format.
-
-        This is a convenience method that calls profile() with the specified format.
-
-        Args:
-            format_type: Output format ("pandas", "dict", "json", "summary")
-
-        Returns:
-            Profile results in requested format
-        """
-        return self.profile(output_format=format_type)
-
-    def quick_profile(self, columns: Optional[List[str]] = None) -> Dict[str, Any]:
-        """
-        Generate a quick profile without advanced statistics for performance.
-
-        Args:
-            columns: List of specific columns to profile. If None, profiles all columns.
-
-        Returns:
-            Basic profile results as dictionary
-        """
-        result = self.profile(
-            columns=columns,
-            output_format="dict",
-            include_advanced=False,
-            include_quality=False,
-        )
-        # Type assertion for mypy
-        assert isinstance(result, dict)
-        return result
-
-    def quality_report(self, columns: Optional[List[str]] = None) -> pd.DataFrame:
-        """
-        Generate a data quality report for specified columns.
-
-        Args:
-            columns: List of specific columns to analyze. If None, analyzes all columns.
-
-        Returns:
-            DataFrame with quality metrics for each column
-        """
-        profile = self.profile(
-            columns=columns,
-            output_format="dict",
-            include_advanced=False,
-            include_quality=True,
-        )
-
-        # Type assertion for mypy
-        assert isinstance(profile, dict)
-
-        # Extract quality metrics into a summary
-        quality_data = []
-        for col_name, col_stats in profile["columns"].items():
-            if "quality" in col_stats:
-                quality_info = {
-                    "column": col_name,
-                    "data_type": col_stats["data_type"],
-                    **col_stats["quality"],
-                }
-                quality_data.append(quality_info)
-
-        return pd.DataFrame(quality_data)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,7 @@ from pyspark.sql.types import (
     ArrayType,
 )
 
-from pyspark_analyzer import DataFrameProfiler, SamplingConfig
+from pyspark_analyzer.profiler import DataFrameProfiler, SamplingConfig
 from pyspark_analyzer.performance import optimize_dataframe_for_profiling
 from pyspark_analyzer.utils import format_profile_output
 
@@ -110,7 +110,7 @@ class TestEndToEndProfiling:
         )
 
         # Profile with auto-sampling enabled using custom config
-        from pyspark_analyzer import SamplingConfig
+        from pyspark_analyzer.sampling import SamplingConfig
 
         sampling_config = SamplingConfig(auto_threshold=50000)  # Lower than 100k rows
         profiler = DataFrameProfiler(

--- a/tests/test_pandas_output.py
+++ b/tests/test_pandas_output.py
@@ -14,7 +14,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 
-from pyspark_analyzer import DataFrameProfiler, SamplingConfig
+from pyspark_analyzer.profiler import DataFrameProfiler, SamplingConfig
 from pyspark_analyzer.utils import format_profile_output
 
 
@@ -152,12 +152,13 @@ class TestPandasOutput:
         assert isinstance(format_profile_output(profile_dict, "summary"), str)
 
     def test_convenience_methods(self, sample_dataframe, tmp_path):
-        """Test to_csv, to_parquet, and format_output methods."""
+        """Test saving profile outputs using pandas methods directly."""
         profiler = DataFrameProfiler(sample_dataframe)
+        profile_df = profiler.profile(output_format="pandas")
 
         # Test to_csv
         csv_path = tmp_path / "profile.csv"
-        profiler.to_csv(str(csv_path), index=False)
+        profile_df.to_csv(str(csv_path), index=False)
         assert csv_path.exists()
 
         # Read back and verify
@@ -168,18 +169,18 @@ class TestPandasOutput:
         # Test to_parquet (skip if pyarrow not installed)
         parquet_path = tmp_path / "profile.parquet"
         try:
-            profiler.to_parquet(str(parquet_path))
+            profile_df.to_parquet(str(parquet_path))
             assert parquet_path.exists()
         except ImportError:
             # Skip parquet test if pyarrow not installed
             pass
 
-        # Test format_output
-        df = profiler.format_output("pandas")
-        assert isinstance(df, pd.DataFrame)
-
-        dict_output = profiler.format_output("dict")
+        # Test different output formats
+        dict_output = profiler.profile(output_format="dict")
         assert isinstance(dict_output, dict)
+
+        pandas_output = profiler.profile(output_format="pandas")
+        assert isinstance(pandas_output, pd.DataFrame)
 
     def test_column_order(self, sample_dataframe):
         """Test that columns are in the expected order."""

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -4,7 +4,7 @@ Test cases for the DataFrame profiler.
 
 import pytest
 
-from pyspark_analyzer import DataFrameProfiler
+from pyspark_analyzer.profiler import DataFrameProfiler
 from pyspark_analyzer.statistics import StatisticsComputer
 from pyspark_analyzer.utils import get_column_data_types, format_profile_output
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -11,7 +11,8 @@ from pyspark.sql.types import (
     DoubleType,
 )
 
-from pyspark_analyzer import DataFrameProfiler, SamplingConfig
+from pyspark_analyzer.profiler import DataFrameProfiler
+from pyspark_analyzer.sampling import SamplingConfig
 from pyspark_analyzer.sampling import SamplingMetadata, apply_sampling
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3069,7 +3069,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/9d/0e/5b38d51f1b1c2618c
 
 [[package]]
 name = "pyspark-analyzer"
-version = "0.3.2"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pandas", version = "2.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
BREAKING CHANGE: Remove DataFrameProfiler from public API. Users should now use the simple analyze() function instead.

- Add new analyze() function as the sole public API
- Remove DataFrameProfiler, SamplingConfig from public exports
- Remove convenience methods (to_csv, to_parquet, etc) from DataFrameProfiler
- Update all examples to use the new simplified API
- Update tests to use internal imports

The new API is much simpler:
```python
from pyspark_analyzer import analyze

# Basic usage
profile = analyze(df)

# Control sampling
profile = analyze(df, sampling=False)
profile = analyze(df, target_rows=100_000)
profile = analyze(df, fraction=0.1)
```

🤖 Generated with [Claude Code](https://claude.ai/code)