### PR TITLE
refactor: remove auto_threshold parameter from sampling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,15 @@ profile = analyze(df, target_rows=100_000, seed=42)
 # Option 3: Sample by fraction
 profile = analyze(df, fraction=0.1, seed=42)  # 10% sample
 
-# Option 4: Custom auto-sampling threshold
-# Auto-sample only if dataset has more than 5M rows
-profile = analyze(df, auto_threshold=5_000_000)
-
-# Option 5: Auto-sampling (default behavior)
-# Automatically samples large datasets (>10M rows by default)
+# Option 4: Auto-sampling (default behavior)
+# Automatically samples large datasets (>10M rows)
 profile = analyze(df)
 
 # Check sampling information (with dict output)
 profile_dict = analyze(df, output_format="dict")
 sampling_info = profile_dict['sampling']
 if sampling_info['is_sampled']:
-    print(f"Sample Quality: {sampling_info['quality_score']:.3f}")
+    print(f"Sample size: {sampling_info['sample_size']:,} rows")
     print(f"Speedup: {sampling_info['estimated_speedup']:.1f}x")
 ```
 

--- a/examples/sampling_example.py
+++ b/examples/sampling_example.py
@@ -118,18 +118,18 @@ def main():
     print("5. CUSTOM AUTO-SAMPLING THRESHOLD")
     print("=" * 70)
 
-    # Lower the auto-sampling threshold to 25,000 rows
+    # Use target_rows to sample to specific size
     profile_custom = analyze(
         df,
-        auto_threshold=25000,  # Auto-sample datasets larger than 25k rows
+        target_rows=25000,  # Sample to approximately 25k rows
         output_format="dict",
     )
 
     sampling_info = profile_custom["sampling"]
-    print("Auto-sampling threshold: 25,000 rows")
+    print("Target sample size: 25,000 rows")
     print("Dataset size: 50,000 rows")
     print(f"Sampling applied: {sampling_info['is_sampled']}")
-    print(f"Sample size: {sampling_info['sample_size']:,} rows")
+    print(f"Actual sample size: {sampling_info['sample_size']:,} rows")
 
     print("\n" + "=" * 70)
     print("6. PERFORMANCE COMPARISON")
@@ -186,9 +186,9 @@ def main():
     profile = analyze(df, fraction=0.05, output_format="dict")
     print(f"   Sample size: {profile['sampling']['sample_size']:,} rows")
 
-    # Example 4: Custom threshold with seed
-    print("\n📌 analyze(df, auto_threshold=30000, seed=42)")
-    profile = analyze(df, auto_threshold=30000, seed=42, output_format="dict")
+    # Example 4: Specific target rows with seed
+    print("\n📌 analyze(df, target_rows=10000, seed=42)")
+    profile = analyze(df, target_rows=10000, seed=42, output_format="dict")
     print(f"   Sampling applied: {profile['sampling']['is_sampled']}")
     print(f"   Sample size: {profile['sampling']['sample_size']:,} rows")
 

--- a/pyspark_analyzer/api.py
+++ b/pyspark_analyzer/api.py
@@ -17,7 +17,6 @@ def analyze(
     include_advanced: bool = True,
     include_quality: bool = True,
     optimize_for_large_datasets: bool = False,
-    auto_threshold: Optional[int] = None,
     seed: Optional[int] = None,
 ) -> Union[pd.DataFrame, dict, str]:
     """
@@ -37,7 +36,6 @@ def analyze(
         include_advanced: Include advanced statistics (skewness, kurtosis, outliers, etc.)
         include_quality: Include data quality metrics
         optimize_for_large_datasets: Use optimized batch processing for better performance
-        auto_threshold: Custom threshold for auto-sampling (default: 10,000,000 rows)
         seed: Random seed for reproducible sampling
 
     Returns:
@@ -71,7 +69,6 @@ def analyze(
         sampling=sampling,
         target_rows=target_rows,
         fraction=fraction,
-        auto_threshold=auto_threshold,
         seed=seed,
     )
 
@@ -94,7 +91,6 @@ def _build_sampling_config(
     sampling: Optional[bool],
     target_rows: Optional[int],
     fraction: Optional[float],
-    auto_threshold: Optional[int],
     seed: Optional[int],
 ) -> SamplingConfig:
     """
@@ -104,7 +100,6 @@ def _build_sampling_config(
         sampling: Whether to enable sampling
         target_rows: Target number of rows to sample
         fraction: Fraction of data to sample
-        auto_threshold: Custom auto-sampling threshold
         seed: Random seed
 
     Returns:
@@ -131,9 +126,6 @@ def _build_sampling_config(
 
     if fraction is not None:
         config_params["fraction"] = fraction
-
-    if auto_threshold is not None:
-        config_params["auto_threshold"] = auto_threshold
 
     if seed is not None:
         config_params["seed"] = seed

--- a/pyspark_analyzer/sampling.py
+++ b/pyspark_analyzer/sampling.py
@@ -18,14 +18,12 @@ class SamplingConfig:
         target_rows: Target number of rows to sample. Takes precedence over fraction.
         fraction: Fraction of data to sample (0-1). Only used if target_rows is not set.
         seed: Random seed for reproducible sampling.
-        auto_threshold: Row count threshold above which auto-sampling kicks in (if enabled=True).
     """
 
     enabled: bool = True
     target_rows: Optional[int] = None
     fraction: Optional[float] = None
     seed: int = 42
-    auto_threshold: int = 10_000_000
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
@@ -102,13 +100,12 @@ def apply_sampling(
         sampling_fraction = config.fraction
         should_sample = sampling_fraction < 1.0
     else:
-        # Auto-sampling based on threshold
-        if row_count > config.auto_threshold:
-            # For datasets over the threshold, sample to the smaller of:
+        # Auto-sampling for large datasets (over 10M rows)
+        if row_count > 10_000_000:
+            # For large datasets, sample to the smaller of:
             # - 1M rows
             # - 10% of the original size
-            # - The auto_threshold itself
-            target_rows = min(1_000_000, int(row_count * 0.1), config.auto_threshold)
+            target_rows = min(1_000_000, int(row_count * 0.1))
             sampling_fraction = min(1.0, target_rows / row_count)
             should_sample = sampling_fraction < 1.0
         else:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -109,10 +109,10 @@ class TestEndToEndProfiling:
             "concat('customer_', id % 10000) as customer_id",
         )
 
-        # Profile with auto-sampling enabled using custom config
+        # Profile with sampling enabled using fraction-based sampling
         from pyspark_analyzer.sampling import SamplingConfig
 
-        sampling_config = SamplingConfig(auto_threshold=50000)  # Lower than 100k rows
+        sampling_config = SamplingConfig(fraction=0.5)  # Sample 50% of data
         profiler = DataFrameProfiler(
             large_df, optimize_for_large_datasets=True, sampling_config=sampling_config
         )
@@ -121,8 +121,8 @@ class TestEndToEndProfiling:
         # Verify sampling was applied
         assert profile["sampling"]["is_sampled"] is True
         assert (
-            profile["sampling"]["sample_size"] <= 100_000
-        )  # May be equal if auto_threshold is at boundary
+            profile["sampling"]["sample_size"] <= 60_000
+        )  # Should be approximately 50k with some variance
         assert profile["sampling"]["sampling_fraction"] <= 1.0
         # quality_score is no longer part of the simplified API
 

--- a/uv.lock
+++ b/uv.lock
@@ -3069,7 +3069,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/9d/0e/5b38d51f1b1c2618c
 
 [[package]]
 name = "pyspark-analyzer"
-version = "1.0.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pandas", version = "2.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
- Remove auto_threshold parameter from analyze() API function
- Remove auto_threshold from SamplingConfig dataclass
- Simplify auto-sampling to use fixed 10M row threshold
- Update tests to remove auto_threshold usage
- Update examples and documentation

BREAKING CHANGE: The auto_threshold parameter has been removed from the analyze() function and SamplingConfig. Auto-sampling now uses a fixed threshold of 10 million rows.

🤖 Generated with [Claude Code](https://claude.ai/code)