### PR TITLE
perf: eliminate extra collection when sampling is applied

### DIFF
--- a/pyspark_analyzer/sampling.py
+++ b/pyspark_analyzer/sampling.py
@@ -50,7 +50,7 @@ class SamplingMetadata:
     """Metadata about a sampling operation."""
 
     original_size: int
-    sample_size: int
+    sample_size: int  # Estimated when sampling is applied
     sampling_fraction: float
     sampling_time: float
     is_sampled: bool
@@ -146,9 +146,12 @@ def apply_sampling(
         )
         try:
             sample_df = df.sample(fraction=sampling_fraction, seed=config.seed)
-            sample_size = sample_df.count()
+            # Estimate sample size instead of counting to avoid extra collection
+            sample_size = int(row_count * sampling_fraction)
             is_sampled = True
-            logger.info(f"Sampling completed: {row_count:,} -> {sample_size:,} rows")
+            logger.info(
+                f"Sampling completed: {row_count:,} -> ~{sample_size:,} rows (estimated)"
+            )
         except (AnalysisException, Py4JError, Py4JJavaError) as e:
             logger.error(f"Failed to sample DataFrame: {str(e)}")
             raise SamplingError(


### PR DESCRIPTION
- Replace sample_df.count() with estimation based on sampling fraction
- Reduces collections from 3 to 2 when sampling is used
- Sample size is now estimated as int(original_count * sampling_fraction)
- Updated logging to indicate estimated sample size

This optimization improves performance for large datasets by avoiding an unnecessary collection to the driver when sampling is applied.

🤖 Generated with [Claude Code](https://claude.ai/code)